### PR TITLE
fit in zeus data pkg style

### DIFF
--- a/dbml/gen_func.go
+++ b/dbml/gen_func.go
@@ -13,7 +13,7 @@ type FuncInfo struct {
 	Body        string
 }
 
-func buildFuncInfo(fn DBMLFunc, hasDataPkg bool, pkg, dbName string) (*FuncInfo, error) {
+func buildFuncInfo(fn DBMLFunc, pkg, externalDB string) (*FuncInfo, error) {
 	if len(fn.DBMLFuncElements) > 1 {
 		return nil, fmt.Errorf("not support gen multiple result set for %s", fn.Method)
 	}
@@ -22,7 +22,7 @@ func buildFuncInfo(fn DBMLFunc, hasDataPkg bool, pkg, dbName string) (*FuncInfo,
 	fi.Name = strings.Title(fn.Method)
 	fi.Inputs = []string{}
 	fi.Inputs = append(fi.Inputs, "ctx context.Context")
-	if !hasDataPkg {
+	if len(externalDB) == 0 {
 		fi.Inputs = append(fi.Inputs, "db *sqlx.DB")
 	}
 
@@ -61,11 +61,11 @@ func buildFuncInfo(fn DBMLFunc, hasDataPkg bool, pkg, dbName string) (*FuncInfo,
 
 	var run string
 
-	if hasDataPkg && len(dbName) > 0 {
+	if len(externalDB) > 0 {
 		if len(fn.DBMLFuncElements) == 0 {
-			run = fmt.Sprintf("_, err = "+pkg+"."+dbName+".ExecContext(ctx, \"%s\"", fn.Name)
+			run = fmt.Sprintf("_, err = "+pkg+"."+externalDB+".ExecContext(ctx, \"%s\"", fn.Name)
 		} else { //len(fn.DBMLFuncElements) == 1
-			run = fmt.Sprintf("err = "+pkg+"."+dbName+".SelectContext(ctx, &rst, \"%s\"", fn.Name)
+			run = fmt.Sprintf("err = "+pkg+"."+externalDB+".SelectContext(ctx, &rst, \"%s\"", fn.Name)
 		}
 	} else {
 		if len(fn.DBMLFuncElements) == 0 {

--- a/dbml/gen_func.go
+++ b/dbml/gen_func.go
@@ -6,14 +6,14 @@ import (
 )
 
 type FuncInfo struct {
-	Name    string
-	Inputs  []string
-	Returns []string
-	Body    string
+	Name        string
+	Inputs      []string
+	Returns     []string
+	FinalReturn string
+	Body        string
 }
 
-func buildFuncInfo(fn DBMLFunc) (*FuncInfo, error) {
-
+func buildFuncInfo(fn DBMLFunc, hasDataPkg bool, pkg, dbName string) (*FuncInfo, error) {
 	if len(fn.DBMLFuncElements) > 1 {
 		return nil, fmt.Errorf("not support gen multiple result set for %s", fn.Method)
 	}
@@ -22,7 +22,9 @@ func buildFuncInfo(fn DBMLFunc) (*FuncInfo, error) {
 	fi.Name = strings.Title(fn.Method)
 	fi.Inputs = []string{}
 	fi.Inputs = append(fi.Inputs, "ctx context.Context")
-	fi.Inputs = append(fi.Inputs, "db *sqlx.DB")
+	if !hasDataPkg {
+		fi.Inputs = append(fi.Inputs, "db *sqlx.DB")
+	}
 
 	if len(fn.Parameters) > 0 {
 		fi.Inputs = append(fi.Inputs, "param *"+fi.Name+"Param")
@@ -35,6 +37,9 @@ func buildFuncInfo(fn DBMLFunc) (*FuncInfo, error) {
 				if strings.Index(p.Name, "p") == 0 || strings.Index(p.Name, "w") == 0 {
 					fieldOut = p.Name[1:]
 				}
+				if fieldOut == "RtnCode" || fieldOut == "RtnMessage" {
+					continue
+				}
 				fieldOut = "out" + fieldOut
 				fieldType = csTypeToGoType(p.Type, false)
 				fieldOut = fieldOut + " *" + fieldType
@@ -43,20 +48,33 @@ func buildFuncInfo(fn DBMLFunc) (*FuncInfo, error) {
 		}
 	}
 
+	var body strings.Builder
 	fi.Returns = []string{}
 	if len(fn.DBMLFuncElements) == 1 {
 		el := fn.DBMLFuncElements[0]
-		fi.Returns = append(fi.Returns, fmt.Sprintf("rst []*%s", strings.Title(el.Name)))
+		fi.Returns = append(fi.Returns, fmt.Sprintf("[]*%s", strings.Title(el.Name)))
+		fi.FinalReturn = "&rst, "
+		body.WriteString("var rst []" + strings.Title(el.Name) + "{}\n\t")
 	}
 	fi.Returns = append(fi.Returns, "err error")
+	fi.FinalReturn += "checkError(err, errCode, errMsg)"
 
-	var body strings.Builder
 	var run string
-	if len(fn.DBMLFuncElements) == 0 {
-		run = fmt.Sprintf("_, err = db.ExecContext(ctx, \"%s\"", fn.Name)
-	} else { //len(fn.DBMLFuncElements) == 1
-		run = fmt.Sprintf("err = db.SelectContext(ctx, &rst, \"%s\"", fn.Name)
+
+	if hasDataPkg && len(dbName) > 0 {
+		if len(fn.DBMLFuncElements) == 0 {
+			run = fmt.Sprintf("_, err = "+pkg+"."+dbName+".ExecContext(ctx, \"%s\"", fn.Name)
+		} else { //len(fn.DBMLFuncElements) == 1
+			run = fmt.Sprintf("err = "+pkg+"."+dbName+".SelectContext(ctx, &rst, \"%s\"", fn.Name)
+		}
+	} else {
+		if len(fn.DBMLFuncElements) == 0 {
+			run = fmt.Sprintf("_, err = db.ExecContext(ctx, \"%s\"", fn.Name)
+		} else { //len(fn.DBMLFuncElements) == 1
+			run = fmt.Sprintf("err = db.SelectContext(ctx, &rst, \"%s\"", fn.Name)
+		}
 	}
+
 	body.WriteString(run)
 
 	var paramFiledName string
@@ -70,7 +88,7 @@ func buildFuncInfo(fn DBMLFunc) (*FuncInfo, error) {
 			paramFiledName = p.Name[1:]
 		}
 		paramFiledName = "param." + strings.Title(paramFiledName)
-		namedfield = fmt.Sprintf(", sql.Named(\"%s\", %s)", p.Name, paramFiledName)
+		namedfield = fmt.Sprintf("\n\t\t,sql.Named(\"%s\", %s)", p.Name, paramFiledName)
 		body.WriteString(namedfield)
 	}
 
@@ -80,13 +98,20 @@ func buildFuncInfo(fn DBMLFunc) (*FuncInfo, error) {
 			if strings.Index(p.Name, "p") == 0 || strings.Index(p.Name, "w") == 0 {
 				paramFiledName = p.Name[1:]
 			}
-			paramFiledName = "out" + strings.Title(paramFiledName)
-			namedfield = fmt.Sprintf(", sql.Named(\"%s\", sql.Out{Dest: %s})", p.Name, paramFiledName)
+
+			if paramFiledName == "RtnCode" {
+				paramFiledName = "&errCode"
+			} else if paramFiledName == "RtnMessage" {
+				paramFiledName = "&errMsg"
+			} else {
+				paramFiledName = "out" + strings.Title(paramFiledName)
+			}
+			namedfield = fmt.Sprintf("\n\t\t,sql.Named(\"%s\", sql.Out{Dest: %s})", p.Name, paramFiledName)
 			body.WriteString(namedfield)
 		}
 	}
 
-	body.WriteString(")")
+	body.WriteString("\n\t)")
 
 	fi.Body = body.String()
 

--- a/dbml/gen_model.go
+++ b/dbml/gen_model.go
@@ -8,19 +8,33 @@ import (
 )
 
 type ModelGen struct {
-	Pkg    string
-	Cls    string
-	Models []*ModelInfo
-	Funcs  []*FuncInfo
+	Pkg          string
+	Cls          string
+	DataPkg      string
+	ErrorPkg     string
+	ErrorPkgName string
+	Models       []*ModelInfo
+	Funcs        []*FuncInfo
 }
 
-func NewModelGen(dbml *DBML, pkg string) *ModelGen {
+func NewModelGen(dbml *DBML, pkg, datapkg, dbName, errorPkg string) *ModelGen {
+	hasDataPkg := false
+	errorPkgList := strings.Split(errorPkg, "/")
+	errorpkgName := errorPkgList[len(errorPkgList)-1]
+
 	mg := &ModelGen{
-		Pkg:    pkg,
-		Cls:    dbml.Class,
-		Models: []*ModelInfo{},
-		Funcs:  []*FuncInfo{},
+		Pkg:          pkg,
+		Cls:          dbml.Class,
+		DataPkg:      datapkg,
+		ErrorPkg:     errorPkg,
+		ErrorPkgName: errorpkgName,
+		Models:       []*ModelInfo{},
+		Funcs:        []*FuncInfo{},
 	}
+	if mg.DataPkg != "" {
+		hasDataPkg = true
+	}
+
 	for _, fn := range dbml.Functions {
 		//input model
 		param := buildParamModel(fn)
@@ -28,7 +42,7 @@ func NewModelGen(dbml *DBML, pkg string) *ModelGen {
 		results := buildResultModels(fn)
 		mg.Models = append(mg.Models, results...)
 
-		spfn, err := buildFuncInfo(fn)
+		spfn, err := buildFuncInfo(fn, hasDataPkg, pkg, dbName)
 		if err != nil {
 			fmt.Println(err)
 			continue

--- a/dbml/gen_model.go
+++ b/dbml/gen_model.go
@@ -17,8 +17,7 @@ type ModelGen struct {
 	Funcs        []*FuncInfo
 }
 
-func NewModelGen(dbml *DBML, pkg, datapkg, dbName, errorPkg string) *ModelGen {
-	hasDataPkg := false
+func NewModelGen(dbml *DBML, pkg, datapkg, externalDB, errorPkg string) *ModelGen {
 	errorPkgList := strings.Split(errorPkg, "/")
 	errorpkgName := errorPkgList[len(errorPkgList)-1]
 
@@ -31,9 +30,6 @@ func NewModelGen(dbml *DBML, pkg, datapkg, dbName, errorPkg string) *ModelGen {
 		Models:       []*ModelInfo{},
 		Funcs:        []*FuncInfo{},
 	}
-	if mg.DataPkg != "" {
-		hasDataPkg = true
-	}
 
 	for _, fn := range dbml.Functions {
 		//input model
@@ -42,7 +38,7 @@ func NewModelGen(dbml *DBML, pkg, datapkg, dbName, errorPkg string) *ModelGen {
 		results := buildResultModels(fn)
 		mg.Models = append(mg.Models, results...)
 
-		spfn, err := buildFuncInfo(fn, hasDataPkg, pkg, dbName)
+		spfn, err := buildFuncInfo(fn, pkg, externalDB)
 		if err != nil {
 			fmt.Println(err)
 			continue

--- a/dbml/gen_test.go
+++ b/dbml/gen_test.go
@@ -21,7 +21,7 @@ func TestGenModel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mg := NewModelGen(dbml, "data")
+	mg := NewModelGen(dbml, "data", "github.acsdev.net/helios/zeus/pkg/data", "GameClub", "github.acsdev.net/helios/zeus/pkg/errors")
 
 	f, err := os.Create("models.go")
 	if err != nil {

--- a/dbml/gen_tpl.go
+++ b/dbml/gen_tpl.go
@@ -30,6 +30,9 @@ import (
     "context"
     "database/sql"
     "github.com/jmoiron/sqlx"
+    
+    {{if .DataPkg}}"{{.DataPkg}}" {{end}}
+    {{if .ErrorPkg}}"{{.ErrorPkg}}" {{end}}
 )
 
 
@@ -39,6 +42,16 @@ var (
     _ = sqlx.DB{}
 )
 
+func checkError(err error, errCode int32, errMsg string) error {
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	if errCode != 0 {
+		return {{.ErrorPkgName}}.Coded(int(errCode), errMsg)
+	}
+	return err
+}
+
 {{range .Funcs}}
 func {{.Name}}(
     {{- range $i, $e := .Inputs -}}
@@ -47,8 +60,11 @@ func {{.Name}}(
     {{- range $j, $k := .Returns -}}
         {{if $j}}, {{end}}{{$k}}
     {{- end}}) {
+    var errCode int32
+    var errMsg string
+
     {{.Body}}
-    return
+    return {{.FinalReturn}}
 }
 {{end}}
 

--- a/main.go
+++ b/main.go
@@ -23,13 +23,13 @@ func main() {
 	var outDir string
 	var pkgName string
 	var dataPkg string
-	var dbName string
+	var externalDB string
 	var errorPkg string
 	flag.StringVar(&dbmlFile, "file", "", "dbml file for gen")
 	flag.StringVar(&pkgName, "pkg", "data", "output pkg namen")
 	flag.StringVar(&outDir, "dir", "", "output dir for gen")
 	flag.StringVar(&dataPkg, "datapkg", "", "pkg where singalten DB(s) appear")
-	flag.StringVar(&dbName, "dbName", "", "DB variable name used to call dB in data pkg")
+	flag.StringVar(&externalDB, "dbName", "", "DB variable name used to call dB in data pkg")
 	flag.StringVar(&errorPkg, "errorPkg", "", "pkg where custumized error to be used")
 	flag.Parse()
 
@@ -45,7 +45,7 @@ func main() {
 		die(err)
 	}
 
-	mg := dbml.NewModelGen(ml, pkgName, dataPkg, dbName, errorPkg)
+	mg := dbml.NewModelGen(ml, pkgName, dataPkg, externalDB, errorPkg)
 
 	if outDir == "" {
 		outDir = pkgName

--- a/main.go
+++ b/main.go
@@ -22,9 +22,15 @@ func main() {
 	var dbmlFile string
 	var outDir string
 	var pkgName string
+	var dataPkg string
+	var dbName string
+	var errorPkg string
 	flag.StringVar(&dbmlFile, "file", "", "dbml file for gen")
 	flag.StringVar(&pkgName, "pkg", "data", "output pkg namen")
 	flag.StringVar(&outDir, "dir", "", "output dir for gen")
+	flag.StringVar(&dataPkg, "datapkg", "", "pkg where singalten DB(s) appear")
+	flag.StringVar(&dbName, "dbName", "", "DB variable name used to call dB in data pkg")
+	flag.StringVar(&errorPkg, "errorPkg", "", "pkg where custumized error to be used")
 	flag.Parse()
 
 	ba, err := ioutil.ReadFile(dbmlFile)
@@ -39,7 +45,7 @@ func main() {
 		die(err)
 	}
 
-	mg := dbml.NewModelGen(ml, pkgName)
+	mg := dbml.NewModelGen(ml, pkgName, dataPkg, dbName, errorPkg)
 
 	if outDir == "" {
 		outDir = pkgName


### PR DESCRIPTION
- newly added dataPkg, dbName, errorPkg for cmd flag
- used data pkg  and db variable to call db when they are specified
- DB output field, pRtnCode, pRtnMessage treat as local variables for customised error checking logic
- edited template
	- added import own pkgs (data/error) when there is a need
	- added customised error checking logic as sql no row error should not treat as kind of error to users
	- return related fields for further operation